### PR TITLE
edk2: Calculate variable store size from file size

### DIFF
--- a/uefivars/edk2.py
+++ b/uefivars/edk2.py
@@ -258,7 +258,7 @@ class EDK2UEFIVarStore(UEFIVarStore):
                          self.EFI_FVB2_WRITE_LOCK_STATUS  | \
                          self.EFI_FVB2_ALIGNMENT_16
         if not hasattr(self, 'varsize'):
-            self.varsize = 0x3ffb8
+            self.varsize = int(self.filelen / 2) - 8264
 
         # Assemble the flash file
         raw = AWSVarStoreFile(tempfile.SpooledTemporaryFile())


### PR DESCRIPTION
We have a (hard coded for now) value for the overall edk2 store size.
However, that store is only a container for the actual variable store
which has its own size field which we did not derive from the overall
size.

That meant that you could get the incorrect impression that you can
choose a different file size while in reality, the resulting store would
not work.

Fix that by calculating the embedded store file size value depending on
the overall store size.

Reported-by: Benjamin Herrenschmidt <benh@amazon.com>
Signed-off-by: Alexander Graf <graf@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
