### PR TITLE
Do deep diff on json tests

### DIFF
--- a/.github/workflows/uefivars.yml
+++ b/.github/workflows/uefivars.yml
@@ -3,11 +3,7 @@
 
 name: Uefivars python application
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: [push, pull_request]
 
 permissions:
   contents: read

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 google_crc32c
+deepdiff

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     long_description=long_description,
     url="https://github.com/awslabs/python-uefivars",
     packages=setuptools.find_packages(),
-    install_requires=['google-crc32c'],
+    install_requires=['google-crc32c', 'deepdiff'],
     entry_points={
         'console_scripts': [
             'uefivars.py = pyuefivars:main',


### PR DESCRIPTION
When we check json output in our tests, we don't really care about the
order of variables. Especially with efivarfs input, the order may differ
based on the underlying file system. So when we check json output, let's
always ignore order.